### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once you have managed to install and access **backstage2**, log in using admin/a
 **Global App Settings**
 - **Application Timezone:** The default timezone of WLOX (the frontend will be seen in each user's timezone).
 - **BTC Miner's Fee:** The fee for sending Bitcoin, collected by the network. We recommend 0.001.
-- **Currency Conversion Fee (%):** A number between 0 and 100 (decimals allowed). The fee collected by WLOX when a trade happens accross currencies.
+- **Currency Conversion Fee (%):** A number between 0 and 100 (decimals allowed). The fee collected by WLOX when a trade happens across currencies.
 - **Exchange's Name:** For example 'MyExchange'. Will be used in place of [exchange_name] in site content.
 - **Fiat Withdrawal Fee:** Not implemented. Leave at 0 for now, unless you want to develop this feature!
 - **Min. Order Amnt. (USD):** The minimum order that can be placed. 


### PR DESCRIPTION
@wlox, I've corrected a typographical error in the documentation of the [wlox](https://github.com/wlox/wlox) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.